### PR TITLE
Fix leaderboard refresh animation

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -7,6 +7,7 @@ const xpBar = document.getElementById("xpBar");
 const xpText = document.getElementById("xpText");
 const leaderboardEl = document.getElementById("leaderboard");
 const achievementsEl = document.getElementById("achievements");
+let leaderboardLoaded = false;
 
 const levelUpSound = new Audio("sounds/level-up.mp3");
 const coinSound = new Audio("sounds/coin.mp3");
@@ -35,16 +36,20 @@ function calculateLevel(xp) {
 }
 
 function animateXPBar(currentXP, xpToNext) {
-  let current = 0;
-  const increment = Math.ceil(currentXP / 120);
+  let current = parseInt(xpBar.value || 0, 10);
+  const distance = Math.abs(currentXP - current);
+  const increment = Math.ceil(distance / 120) || 1;
+  const direction = currentXP >= current ? 1 : -1;
 
   const animate = () => {
-    current += increment;
-    if (current > currentXP) current = currentXP;
+    current += increment * direction;
+    if ((direction === 1 && current > currentXP) || (direction === -1 && current < currentXP)) {
+      current = currentXP;
+    }
     xpBar.value = current;
     xpText.textContent = `${current} / ${xpToNext} XP`;
 
-    if (current < currentXP) {
+    if (current !== currentXP) {
       requestAnimationFrame(animate);
     }
   };
@@ -148,6 +153,9 @@ function updateDisplay(data) {
   }
 
 
+  if (leaderboardLoaded) {
+    leaderboardEl.classList.add("loaded");
+  }
   leaderboardEl.innerHTML = "";
   data.leaderboard
     .sort((a, b) => b.xp - a.xp)
@@ -162,6 +170,9 @@ function updateDisplay(data) {
       li.appendChild(span);
       leaderboardEl.appendChild(li);
     });
+  if (!leaderboardLoaded) {
+    leaderboardLoaded = true;
+  }
   previousLevel = progress.level;
   previousXP = progress.totalXP;
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -83,6 +83,11 @@ ul#leaderboard li {
   opacity: 0;
 }
 
+ul#leaderboard.loaded li {
+  animation: none;
+  opacity: 1;
+}
+
 ul#leaderboard li:nth-child(1) {
   animation-delay: 0.1s;
 }


### PR DESCRIPTION
## Summary
- prevent leaderboard entries from reanimating on each update

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684058598c18832495d5d220fe78b83c