### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Workforce Management Team</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/docs/script.js
+++ b/docs/script.js
@@ -101,11 +101,7 @@ function loadAchievementsAndXP() {
         img.src = file.download_url;
         img.alt = displayTitle;
         img.title = displayTitle;
-        img.style.width = "128px";
-        img.style.height = "128px";
-        img.style.objectFit = "contain";
-        img.style.borderRadius = "12px";
-        img.style.boxShadow = "0 0 6px rgba(0, 0, 0, 0.3)";
+        img.className = "achievement";
         grid.appendChild(img);
       });
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -5,13 +5,17 @@
   box-sizing: border-box;
 }
 
+html {
+  font-size: clamp(16px, 4vw, 20px);
+}
+
 body {
   font-family: "Outfit", sans-serif;
   background: linear-gradient(to bottom, #0f2027, #203a43, #2c5364);
   background-attachment: fixed;
   background-size: cover;
   color: #fff;
-  padding: 2rem;
+  padding: clamp(1rem, 2vw, 2rem);
   max-width: 700px;
   margin: auto;
   text-align: center;
@@ -24,12 +28,12 @@ h2 {
 }
 
 h1 {
-  font-size: 2.5rem;
+  font-size: clamp(2rem, 6vw, 2.5rem);
   text-shadow: 1px 1px 4px #000;
 }
 
 h2 {
-  font-size: 1.5rem;
+  font-size: clamp(1.25rem, 4vw, 1.5rem);
   border-bottom: 2px solid #fff3;
   display: inline-block;
   padding-bottom: 0.3rem;
@@ -38,7 +42,7 @@ h2 {
 /* XP Bar */
 #xpBar {
   width: 100%;
-  height: 30px;
+  height: clamp(24px, 6vw, 30px);
   margin: 1rem 0;
   appearance: none;
 }
@@ -57,7 +61,7 @@ progress::-webkit-progress-value {
 
 #xpText {
   margin-bottom: 2rem;
-  font-size: 1.1rem;
+  font-size: clamp(1rem, 3vw, 1.1rem);
   color: #aaddff;
 }
 
@@ -102,8 +106,8 @@ ul#leaderboard li:nth-child(3) {
 ul#leaderboard img {
   border-radius: 50%;
   border: 2px solid #00c6ff;
-  width: 48px;
-  height: 48px;
+  width: clamp(40px, 8vw, 48px);
+  height: clamp(40px, 8vw, 48px);
   transition: transform 0.3s, box-shadow 0.3s;
 }
 
@@ -120,6 +124,14 @@ ul#leaderboard li:hover img {
   max-height: 400px;
   overflow-y: auto;
   padding-top: 0;
+}
+
+.achievement {
+  width: clamp(80px, 25vw, 128px);
+  height: clamp(80px, 25vw, 128px);
+  object-fit: contain;
+  border-radius: 12px;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.3);
 }
 
 /* Animations */


### PR DESCRIPTION
## Summary
- add viewport meta tag for proper scaling on phones
- use CSS `clamp()` to adapt font sizes and element sizing
- make achievement icons responsive by applying a CSS class

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840cb24cad48324818b2cd57162e0ee