### PR TITLE
Add workflows for main and experimental Pages deploys

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -1,0 +1,36 @@
+name: Deploy Experimental to GitHub Pages
+
+on:
+  push:
+    branches:
+      - experimental
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout experimental branch
+        uses: actions/checkout@v4
+
+      - name: Prepare subfolder for experimental
+        run: |
+          mkdir -p site/experimental
+          cp -r docs/* site/experimental/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload experimental site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,0 +1,31 @@
+name: Deploy Main to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload site from main branch (root)
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add workflow deploying `docs/` on `main`
- add workflow deploying under `experimental/` on `experimental`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684172c56c18832494e64b0c84e51078