### PR TITLE
Add experimental site deployment

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -1,0 +1,39 @@
+name: Deploy Experimental Site
+
+on:
+  push:
+    branches:
+      - Experimental
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-experimental.yml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main
+
+      - name: Checkout Experimental branch
+        uses: actions/checkout@v4
+        with:
+          ref: Experimental
+          path: experimental
+
+      - name: Sync experimental site
+        run: |
+          rm -rf main/docs/experimental
+          cp -r experimental/docs main/docs/experimental
+
+      - name: Commit changes
+        run: |
+          cd main
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/experimental
+          git diff --cached --quiet || git commit -m "🚀 Deploy experimental site"
+          git push --force-with-lease

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A static web dashboard (hosted via GitHub Pages) that:
 - Automatically levels up the team with celebratory sounds and confetti
 - Displays a live leaderboard with GitHub avatars
 - Collects and displays visual achievements (badges) in a scrollable gallery
+- Deploys an `/experimental` build from the `Experimental` branch for testing
 
 Ideal for running on a screen in a team room — encouraging celebration, progress, and a bit of fun competition.
 


### PR DESCRIPTION
## Summary
- add workflow to deploy the `Experimental` branch to `docs/experimental`
- document the `/experimental` path in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68418ea974d08324bd478aaed89fb948