### PR TITLE
Switch leaderboard to recent activity feed

### DIFF
--- a/.github/scripts/update-badges.js
+++ b/.github/scripts/update-badges.js
@@ -4,7 +4,7 @@ const path = require('path');
 const xpPath = path.join(__dirname, '../../docs/xp.json');
 const badgesDir = path.join(__dirname, '../../docs/achievements');
 
-let xpData = { xp: 0, leaderboard: [] };
+let xpData = { xp: 0, recent: [], badges: [] };
 if (fs.existsSync(xpPath)) {
   xpData = JSON.parse(fs.readFileSync(xpPath, 'utf8'));
 }

--- a/.github/scripts/update-xp.js
+++ b/.github/scripts/update-xp.js
@@ -22,18 +22,17 @@ if (!assignee || !xpAmount) {
   process.exit(0);
 }
 
-let xpData = { xp: 0, level: 1, xpToNext: 100, leaderboard: [] };
+let xpData = { xp: 0, recent: [], badges: [] };
 if (fs.existsSync(xpPath)) {
   xpData = JSON.parse(fs.readFileSync(xpPath, "utf8"));
 }
 
 xpData.xp += xpAmount;
 
-const userEntry = xpData.leaderboard.find((u) => u.user === assignee);
-if (userEntry) {
-  userEntry.xp += xpAmount;
-} else {
-  xpData.leaderboard.push({ user: assignee, xp: xpAmount });
+xpData.recent = xpData.recent || [];
+xpData.recent.unshift({ user: assignee, title: issue.title, xp: xpAmount });
+if (xpData.recent.length > 5) {
+  xpData.recent.pop();
 }
 
 fs.writeFileSync(xpPath, JSON.stringify(xpData, null, 2));

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A static web dashboard (hosted via GitHub Pages) that:
 
 - Tracks completed issues and assigns XP based on custom templates
 - Automatically levels up the team with celebratory sounds and confetti
-- Displays a live leaderboard with GitHub avatars
+- Shows a feed of the latest completed issues with GitHub avatars
 - Collects and displays visual achievements (badges) in a scrollable gallery
 
 Ideal for running on a screen in a team room — encouraging celebration, progress, and a bit of fun competition.

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
     <progress id="xpBar" value="0" max="200"></progress>
     <p id="xpText">0 / 200 XP</p>
 
-    <h2>Leaderboard</h2>
+    <h2>Recent Activity</h2>
     <ul id="leaderboard"></ul>
     <h2>Achievements</h2>
     <div id="achievements"></div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -158,7 +158,7 @@ function loadAchievementsAndXP() {
 
       updateDisplay({
         xp: data.xp || 0,
-        leaderboard: data.leaderboard || [],
+        recent: data.recent || [],
       });
     });
 }
@@ -198,19 +198,17 @@ function updateDisplay(data) {
     leaderboardEl.classList.add("loaded");
   }
   leaderboardEl.innerHTML = "";
-  data.leaderboard
-    .sort((a, b) => b.xp - a.xp)
-    .forEach((entry) => {
-      const li = document.createElement("li");
-      const img = document.createElement("img");
-      img.src = `https://github.com/${entry.user}.png?size=64`;
-      img.alt = entry.user;
-      const span = document.createElement("span");
-      span.textContent = `${entry.user} - ${entry.xp} XP`;
-      li.appendChild(img);
-      li.appendChild(span);
-      leaderboardEl.appendChild(li);
-    });
+  data.recent.forEach((entry) => {
+    const li = document.createElement("li");
+    const img = document.createElement("img");
+    img.src = `https://github.com/${entry.user}.png?size=64`;
+    img.alt = entry.user;
+    const span = document.createElement("span");
+    span.textContent = `${entry.user} closed ${entry.title} + ${entry.xp}XP`;
+    li.appendChild(img);
+    li.appendChild(span);
+    leaderboardEl.appendChild(li);
+  });
   if (!leaderboardLoaded) {
     leaderboardLoaded = true;
   }

--- a/docs/style.css
+++ b/docs/style.css
@@ -65,7 +65,7 @@ progress::-webkit-progress-value {
   color: #aaddff;
 }
 
-/* Leaderboard */
+/* Activity Feed */
 ul#leaderboard {
   margin-bottom: 2rem;
   list-style: none;

--- a/docs/xp.json
+++ b/docs/xp.json
@@ -1,15 +1,5 @@
 {
   "xp": 2270,
-  "leaderboard": [
-    {
-      "user": "JoachimHolseter",
-      "xp": 400
-    },
-    {
-      "user": "JoachimHolseterBouvet",
-      "xp": 670
-    }
-  ],
   "badges": [
     {
       "file": "1_200XP_API-Team-lvl1.png",
@@ -47,5 +37,6 @@
       "xp": 150,
       "level": 1
     }
-  ]
+  ],
+  "recent": []
 }


### PR DESCRIPTION
## Summary
- tweak README to mention activity feed
- use `Recent Activity` heading in the dashboard
- support `recent` entries in `script.js`
- adjust CSS comment
- simplify `xp.json` to store only total XP, badges and last five entries
- update GitHub action scripts for new JSON format

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684196d04a7c8324b510ec334e612474