### PR TITLE
Fix gradient and minor script cleanup

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -216,7 +216,7 @@ function updateDisplay(data) {
   previousXP = progress.totalXP;
 }
 
-fetchAndUpdate = loadAchievementsAndXP;
+const fetchAndUpdate = loadAchievementsAndXP;
 fetchAndUpdate();
 // Poll every 30 seconds instead of 10 to reduce API requests
 setInterval(fetchAndUpdate, 30000);

--- a/docs/style.css
+++ b/docs/style.css
@@ -11,7 +11,7 @@ html {
 
 body {
   font-family: "Outfit", sans-serif;
-  background: linear-gradient(to bottom, #0f2027, #203a43, #2c5364);
+  background: linear-gradient(to bottom, #330000, #990000, #cc3333);
   background-attachment: fixed;
   background-size: cover;
   color: #fff;


### PR DESCRIPTION
## Summary
- adjust main page background gradient to a reddish theme
- define `fetchAndUpdate` const before polling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841a16f69888324951f32ec42488e33